### PR TITLE
Update image url that returning high quality images

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@
   </a>
 </p>
 
-*WARNING: Fetching high resolution pokemon images from https://pokeres.bastionbot.org/images/pokemon/{id}.png is not possible any more.
-At this time I don't have API alternatives to solve this issue.*
-
 A Pokedex Android app built with Kotlin, using [PokeAPI](https://pokeapi.co/) datasource.
 
 <p align="left">

--- a/data/model/src/main/kotlin/com/hivian/model/mapper/Mapper.kt
+++ b/data/model/src/main/kotlin/com/hivian/model/mapper/Mapper.kt
@@ -90,7 +90,7 @@ class MapperPokemonRemoteToDbImpl : Mapper<NetworkPokemonObject, DbPokemon>() {
             forms = input.forms.map { it.name },
             moves = input.moves.map { it.move.name },
             // High resolution image source.
-            imageUrl = "https://pokeres.bastionbot.org/images/pokemon/${input.id}.png",
+            imageUrl = "https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${input.id.padStart(3, '0'))}.png"
             stats = input.stats.map { DbPokemonStat(
                 name = it.stat.name,
                 baseStat = it.baseStat,

--- a/data/model/src/main/kotlin/com/hivian/model/mapper/Mapper.kt
+++ b/data/model/src/main/kotlin/com/hivian/model/mapper/Mapper.kt
@@ -90,7 +90,7 @@ class MapperPokemonRemoteToDbImpl : Mapper<NetworkPokemonObject, DbPokemon>() {
             forms = input.forms.map { it.name },
             moves = input.moves.map { it.move.name },
             // High resolution image source.
-            imageUrl = "https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${input.id.padStart(3, '0'))}.png"
+            imageUrl = "https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${input.id.toString().padStart(3, '0'))}.png"
             stats = input.stats.map { DbPokemonStat(
                 name = it.stat.name,
                 baseStat = it.baseStat,

--- a/data/repository/src/test/java/com/hivian/repository/PokemonItemMapperTest.kt
+++ b/data/repository/src/test/java/com/hivian/repository/PokemonItemMapperTest.kt
@@ -31,7 +31,7 @@ class PokemonItemMapperTest {
             assertEquals("Circle", forms.first())
             assertEquals("Fireball", abilities.first().name)
 
-            assertEquals("https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${input.id.padStart(3, '0'))}.png", imageUrl)
+            assertEquals("https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${input.id.toString().padStart(3, '0'))}.png", imageUrl)
             assertEquals(0, stats.first().baseStat)
         }
     }

--- a/data/repository/src/test/java/com/hivian/repository/PokemonItemMapperTest.kt
+++ b/data/repository/src/test/java/com/hivian/repository/PokemonItemMapperTest.kt
@@ -30,7 +30,8 @@ class PokemonItemMapperTest {
             assertEquals("Name_0", name)
             assertEquals("Circle", forms.first())
             assertEquals("Fireball", abilities.first().name)
-            assertEquals("https://pokeres.bastionbot.org/images/pokemon/${id}.png", imageUrl)
+
+            assertEquals("https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/${input.id.padStart(3, '0'))}.png", imageUrl)
             assertEquals(0, stats.first().baseStat)
         }
     }


### PR DESCRIPTION
Update image url from https://pokeres.bastionbot.org/ to https://raw.githubusercontent.com/.

Example:
- Doesn't work:
   https://pokeres.bastionbot.org/images/pokemon/7.png

- It works:
   https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/007.png